### PR TITLE
Fix validity error

### DIFF
--- a/lua/weapons/meteors_grenade_base_model.lua
+++ b/lua/weapons/meteors_grenade_base_model.lua
@@ -180,6 +180,8 @@ if CLIENT then
 end
 
 function SWEP:Deploy()
+	if not IsValid(self.Owner) then return end
+
 	if SERVER and (self:Clip1() <= 0 and self.Owner:GetAmmoCount(self.Primary.Ammo) <= 0) then -- Make sure we can not equip a Grenade when we do not even have one!
 		self.Owner:StripWeapon(self:GetClass())
 	end


### PR DESCRIPTION
No idea how or when this happens, but I'm guessing it's a simple fix regardless.

On the off chance that `self.Owner` is being set to something other than a player, then it should be fixed there instead (I didn't see any where that could happen).

```lua
lua/weapons/meteors_grenade_base_model.lua:190: attempt to call method 'GetViewModel' (a nil value)
   0.  GetViewModel - [C]:-1
    1.  unkown - lua/weapons/meteors_grenade_base_model.lua:190
```
